### PR TITLE
fix: drop a default the output-summary attribute does not have

### DIFF
--- a/_extensions/collapse-output/_schema.yml
+++ b/_extensions/collapse-output/_schema.yml
@@ -42,8 +42,7 @@ attributes:
       description: "Wrap cell output in a collapsible details element."
     output-summary:
       type: string
-      default: "Code Output"
-      description: "Summary text shown on the collapsed output toggle. Overrides templates and per-type summaries."
+      description: "Summary text shown on the collapsed output toggle, taking precedence over both `summaries` and `summary-template`. Unset, the summary comes from `summaries` for the detected output type, then from `summary-template`."
     output-open:
       type: boolean
       description: "Per-cell override of the document 'default-open' setting."


### PR DESCRIPTION
The schema gave `output-summary` a default of `"Code Output"`. That string is `DEFAULT_TYPE_SUMMARIES.output`, the label for the output type named `output`, rather than a default for the attribute. Unset, the summary falls through to `summaries` for the detected type and then to `summary-template`.

Schema only; the filter is unchanged, and the reference page already documented the fallback chain correctly.