### PR TITLE
refactor: Target Quarto Wizard v2 extension schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Refactoring
+
+- refactor: Target the Quarto Wizard v2 extension schema in `_schema.yml`, renaming `enum-case-insensitive` to `enumCaseInsensitive`.
+
 ## 1.5.1 (2026-08-01)
 
 ### Documentation

--- a/_extensions/collapse-output/_schema.yml
+++ b/_extensions/collapse-output/_schema.yml
@@ -2,14 +2,14 @@
 # Provides configuration validation and IDE support for options
 # and attributes.
 
-$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v2/extension-schema.json
 
 options:
   method:
     type: string
     default: "lua"
     enum: [lua, javascript]
-    enum-case-insensitive: true
+    enumCaseInsensitive: true
     description: "Collapsing method. 'lua' renders server-side; 'javascript' renders client-side."
   collapse-all-outputs:
     type: boolean


### PR DESCRIPTION
Points `_schema.yml` at the Quarto Wizard v2 meta-schema and renames `enum-case-insensitive` to `enumCaseInsensitive`. v2 uses JSON Schema 2020-12 canonical names exclusively, so the v1 spelling no longer validates and editors ignored the flag on `method`.